### PR TITLE
Add EF Core persistence

### DIFF
--- a/CampBookingApi/CampBookingApi.csproj
+++ b/CampBookingApi/CampBookingApi.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/CampBookingApi/Controllers/CampsController.cs
+++ b/CampBookingApi/Controllers/CampsController.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Mvc;
+using CampBookingApi.Models;
+using CampBookingApi.Services;
+
+namespace CampBookingApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CampsController : ControllerBase
+    {
+        private readonly ICampService _campService;
+
+        public CampsController(ICampService campService)
+        {
+            _campService = campService;
+        }
+
+        [HttpGet]
+        public ActionResult<IEnumerable<Camp>> GetAll()
+        {
+            return Ok(_campService.GetAll());
+        }
+
+        [HttpGet("{id:int}")]
+        public ActionResult<Camp> GetById(int id)
+        {
+            var camp = _campService.GetById(id);
+            if (camp is null) return NotFound();
+            return Ok(camp);
+        }
+
+        [HttpPost]
+        public ActionResult<Camp> Create(Camp camp)
+        {
+            var created = _campService.Create(camp);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id:int}")]
+        public IActionResult Update(int id, Camp updatedCamp)
+        {
+            var camp = _campService.Update(id, updatedCamp);
+            if (camp is null) return NotFound();
+            return Ok(camp);
+        }
+
+        [HttpDelete("{id:int}")]
+        public IActionResult Delete(int id)
+        {
+            if (!_campService.Delete(id))
+                return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/CampBookingApi/Controllers/CustomersController.cs
+++ b/CampBookingApi/Controllers/CustomersController.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Mvc;
+using CampBookingApi.Models;
+using CampBookingApi.Services;
+
+namespace CampBookingApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CustomersController : ControllerBase
+    {
+        private readonly ICustomerService _customerService;
+
+        public CustomersController(ICustomerService customerService)
+        {
+            _customerService = customerService;
+        }
+
+        [HttpGet]
+        public ActionResult<IEnumerable<Customer>> GetAll()
+        {
+            return Ok(_customerService.GetAll());
+        }
+
+        [HttpGet("{id:int}")]
+        public ActionResult<Customer> GetById(int id)
+        {
+            var customer = _customerService.GetById(id);
+            if (customer is null) return NotFound();
+            return Ok(customer);
+        }
+
+        [HttpPost]
+        public ActionResult<Customer> Create(Customer customer)
+        {
+            var created = _customerService.Create(customer);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id:int}")]
+        public IActionResult Update(int id, Customer updatedCustomer)
+        {
+            var customer = _customerService.Update(id, updatedCustomer);
+            if (customer is null) return NotFound();
+            return Ok(customer);
+        }
+
+        [HttpDelete("{id:int}")]
+        public IActionResult Delete(int id)
+        {
+            if (!_customerService.Delete(id))
+                return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/CampBookingApi/Data/ApplicationDbContext.cs
+++ b/CampBookingApi/Data/ApplicationDbContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using CampBookingApi.Models;
+
+namespace CampBookingApi.Data
+{
+    public class ApplicationDbContext : DbContext
+    {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Camp> Camps => Set<Camp>();
+        public DbSet<Customer> Customers => Set<Customer>();
+    }
+}

--- a/CampBookingApi/Models/Camp.cs
+++ b/CampBookingApi/Models/Camp.cs
@@ -1,0 +1,10 @@
+namespace CampBookingApi.Models
+{
+    public class Camp
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+        public int Capacity { get; set; }
+    }
+}

--- a/CampBookingApi/Models/Customer.cs
+++ b/CampBookingApi/Models/Customer.cs
@@ -1,0 +1,10 @@
+namespace CampBookingApi.Models
+{
+    public class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string Phone { get; set; } = string.Empty;
+    }
+}

--- a/CampBookingApi/Program.cs
+++ b/CampBookingApi/Program.cs
@@ -1,0 +1,19 @@
+using CampBookingApi.Data;
+using CampBookingApi.Services;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddScoped<ICampService, CampService>();
+builder.Services.AddScoped<ICustomerService, CustomerService>();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();

--- a/CampBookingApi/Services/CampService.cs
+++ b/CampBookingApi/Services/CampService.cs
@@ -1,0 +1,47 @@
+using CampBookingApi.Data;
+using CampBookingApi.Models;
+
+namespace CampBookingApi.Services
+{
+    public class CampService : ICampService
+    {
+        private readonly ApplicationDbContext _context;
+
+        public CampService(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public IEnumerable<Camp> GetAll() => _context.Camps.ToList();
+
+        public Camp? GetById(int id) => _context.Camps.Find(id);
+
+        public Camp Create(Camp camp)
+        {
+            _context.Camps.Add(camp);
+            _context.SaveChanges();
+            return camp;
+        }
+
+        public Camp? Update(int id, Camp camp)
+        {
+            var existing = _context.Camps.Find(id);
+            if (existing is null) return null;
+
+            existing.Name = camp.Name;
+            existing.Location = camp.Location;
+            existing.Capacity = camp.Capacity;
+            _context.SaveChanges();
+            return existing;
+        }
+
+        public bool Delete(int id)
+        {
+            var camp = _context.Camps.Find(id);
+            if (camp is null) return false;
+            _context.Camps.Remove(camp);
+            _context.SaveChanges();
+            return true;
+        }
+    }
+}

--- a/CampBookingApi/Services/CustomerService.cs
+++ b/CampBookingApi/Services/CustomerService.cs
@@ -1,0 +1,47 @@
+using CampBookingApi.Data;
+using CampBookingApi.Models;
+
+namespace CampBookingApi.Services
+{
+    public class CustomerService : ICustomerService
+    {
+        private readonly ApplicationDbContext _context;
+
+        public CustomerService(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public IEnumerable<Customer> GetAll() => _context.Customers.ToList();
+
+        public Customer? GetById(int id) => _context.Customers.Find(id);
+
+        public Customer Create(Customer customer)
+        {
+            _context.Customers.Add(customer);
+            _context.SaveChanges();
+            return customer;
+        }
+
+        public Customer? Update(int id, Customer customer)
+        {
+            var existing = _context.Customers.Find(id);
+            if (existing is null) return null;
+
+            existing.Name = customer.Name;
+            existing.Email = customer.Email;
+            existing.Phone = customer.Phone;
+            _context.SaveChanges();
+            return existing;
+        }
+
+        public bool Delete(int id)
+        {
+            var customer = _context.Customers.Find(id);
+            if (customer is null) return false;
+            _context.Customers.Remove(customer);
+            _context.SaveChanges();
+            return true;
+        }
+    }
+}

--- a/CampBookingApi/Services/ICampService.cs
+++ b/CampBookingApi/Services/ICampService.cs
@@ -1,0 +1,13 @@
+using CampBookingApi.Models;
+
+namespace CampBookingApi.Services
+{
+    public interface ICampService
+    {
+        IEnumerable<Camp> GetAll();
+        Camp? GetById(int id);
+        Camp Create(Camp camp);
+        Camp? Update(int id, Camp camp);
+        bool Delete(int id);
+    }
+}

--- a/CampBookingApi/Services/ICustomerService.cs
+++ b/CampBookingApi/Services/ICustomerService.cs
@@ -1,0 +1,13 @@
+using CampBookingApi.Models;
+
+namespace CampBookingApi.Services
+{
+    public interface ICustomerService
+    {
+        IEnumerable<Customer> GetAll();
+        Customer? GetById(int id);
+        Customer Create(Customer customer);
+        Customer? Update(int id, Customer customer);
+        bool Delete(int id);
+    }
+}

--- a/CampBookingApi/appsettings.json
+++ b/CampBookingApi/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=AKASHJATWA\\SQLEXPRESS;Database=MyApplicationDB;Trusted_Connection=True;TrustServerCertificate=True;"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# MyApplication
+# Camp Booking API
+
+This repository contains an ASP.NET 6 Web API for managing camps and customers in a booking system.
+The API now uses Entity Framework Core with SQL Server for persistence.
+The default connection string is stored in `appsettings.json`:
+
+```
+"ConnectionStrings": {
+  "DefaultConnection": "Server=AKASHJATWA\\SQLEXPRESS;Database=MyApplicationDB;Trusted_Connection=True;TrustServerCertificate=True;"
+}
+```
+
+## Running the project
+
+1. Install the .NET 6 SDK.
+2. Navigate to the API directory and run the application:
+
+```bash
+cd CampBookingApi
+dotnet run
+```
+
+The API exposes controller-based endpoints to manage camps and customers. You can create, update, or delete camp and customer records through the corresponding `/api/camps` and `/api/customers` endpoints.


### PR DESCRIPTION
## Summary
- connect to SQL Server using Entity Framework Core
- use `ApplicationDbContext` to store camps and customers
- register EF Core and services via dependency injection
- configure the connection string in `appsettings.json`
- document EF Core usage in the README

## Testing
- `dotnet build CampBookingApi/CampBookingApi.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3e25ef88832aa8cf8aa39c1db398